### PR TITLE
dicif

### DIFF
--- a/aya_lilith/_loading_order.txt
+++ b/aya_lilith/_loading_order.txt
@@ -1,2 +1,2 @@
 dic, aya_lilith.dic, UTF-8
-dic, aya_lilith_ex.dic, UTF-8
+dicif, aya_lilith_ex.dic, UTF-8

--- a/yaya_base/_loading_order.txt
+++ b/yaya_base/_loading_order.txt
@@ -1,4 +1,4 @@
 dic, config.dic, UTF-8
 dic, shiori3.dic, UTF-8
-dic, optional.dic, UTF-8
-# dic, compatible.dic, UTF-8
+dicif, optional.dic, UTF-8
+dicif, compatible.dic, UTF-8


### PR DESCRIPTION
In the English ukagaka community there was some discussion yesterday about the newer version of yaya, including the update of aya to yaya stuff
Some of the issues included the lack of `NAMETOVALUE` after updating to the latest version, people needing to manually modify `_loading_order.txt`, and confusion over the msglang and messagetxt options (Confusion caused by several different advocated updates)
So I'm thinking whether it would be more appropriate to change some of the options to **dicif**

____

I was also thinking that we might be able to maintain different config yaya_dic folders via different branches to facilitate updates for those who have these dic's set as sub-models.